### PR TITLE
Use v2 api for trip lookup and handle variable precision encoded polyline

### DIFF
--- a/bin/motis-m
+++ b/bin/motis-m
@@ -270,7 +270,7 @@ if ($raw_json_output) {
 }
 
 if ($json_output) {
-	if ( $opt{journey} ) {
+	if ( $opt{trip_id} ) {
 		say JSON->new->convert_blessed->encode( $status->result );
 	}
 	else {

--- a/lib/Travel/Status/MOTIS.pm
+++ b/lib/Travel/Status/MOTIS.pm
@@ -83,7 +83,7 @@ sub new {
 		);
 	}
 	elsif ( my $trip_id = $conf{trip_id} ) {
-		$request_url->path('api/v1/trip');
+		$request_url->path('api/v2/trip');
 		$request_url->query_form(
 			tripId => $trip_id,
 		);

--- a/lib/Travel/Status/MOTIS/Polyline.pm
+++ b/lib/Travel/Status/MOTIS/Polyline.pm
@@ -23,7 +23,10 @@ our $VERSION = '0.01';
 # <http://unitstep.net/blog/2008/08/02/decoding-google-maps-encoded-polylines-using-php/>
 # to perl
 sub decode_polyline {
-	my ($encoded) = @_;
+	my ( $input ) = @_;
+
+	my $encoded = $input->{points};
+	my $precision = $input->{precision};
 
 	my $length = length $encoded;
 	my $index  = 0;
@@ -80,14 +83,14 @@ sub decode_polyline {
 		}
 
 		# The actual latitude and longitude values were multiplied by
-		# 1e5 before encoding so that they could be converted to a 32-bit
-		# integer representation. (With a decimal accuracy of 7 places)
+		# 1e$precision before encoding so that they could be converted to a 32-bit
+		# integer representation. (With a decimal accuracy of $precision places)
 		# Convert back to original values.
 		push(
 			@points,
 			{
-				lat => $lat * 1e-7,
-				lon => $lon * 1e-7
+				lat => $lat * (10 ** -$precision),
+				lon => $lon * (10 ** -$precision),
 			}
 		);
 	}

--- a/lib/Travel/Status/MOTIS/Trip.pm
+++ b/lib/Travel/Status/MOTIS/Trip.pm
@@ -165,8 +165,8 @@ sub stopovers {
 sub TO_JSON {
 	my ($self) = @_;
 
-	# transform raw_route into route (lazy accessor)
-	$self->route;
+	# transform raw_stopovers into stopovers (lazy accessor)
+	$self->stopovers;
 
 	# transform raw_polyline into polyline (lazy accessor)
 	$self->polyline;

--- a/lib/Travel/Status/MOTIS/Trip.pm
+++ b/lib/Travel/Status/MOTIS/Trip.pm
@@ -53,7 +53,7 @@ sub new {
 
 		raw_stopovers =>
 		  [ $json->{from}, @{ $json->{intermediateStops} }, $json->{to} ],
-		raw_polyline => $json->{legGeometry}->{points},
+		raw_polyline => $json->{legGeometry},
 	};
 
 	$ref->{scheduled_departure} = DateTime::Format::ISO8601->parse_datetime(


### PR DESCRIPTION
This pull request updates the trip lookup codepath to use `api/v2/trip`, which contains a breaking change with the precision of encoded polylines, making it depend on a json value returned by the api.

See https://github.com/motis-project/motis/commit/cdca7497b0f5a8a23a6f05a3ea64fe59f199cd0a