### PR TITLE
Properly handle time zone constructor parameter

### DIFF
--- a/lib/Travel/Status/MOTIS.pm
+++ b/lib/Travel/Status/MOTIS.pm
@@ -59,7 +59,7 @@ sub new {
 		results        => [],
 		station        => $conf{station},
 		user_agent     => $user_agent,
-		time_zone      => 'local',
+		time_zone      => $conf{time_zone} // 'local',
 	};
 
 	bless( $self, $obj );


### PR DESCRIPTION
This pull request fixes the constructor parameter previously introduced in 16e6eb63a992941b420f63ad9cef9caa5115b851 not actually doing anything.

I guess I'm still not that used to writing perl :sweat_smile: 